### PR TITLE
simplifying specs for dummy example

### DIFF
--- a/specifications/configuration.yml
+++ b/specifications/configuration.yml
@@ -1,19 +1,13 @@
 specifications:
-- name: Container
-  status: revision
-  spec_type: Profile
-  use_cases_url: https://www.github.com/openschemas/spec-container
-  version: 0.0.1
-  parent_type: SoftwareApplication
 - name: ContainerRecipe
   status: revision
   spec_type: Profile
   use_cases_url: https://www.github.com/openschemas/spec-container
   version: 0.0.1
-  parent_type: SoftwareApplication
+  parent_type: SoftwareSourceCode
 - name: ContainerImage
   status: revision
   spec_type: Profile
   use_cases_url: https://www.github.com/openschemas/spec-container
   version: 0.0.1
-  parent_type: SoftwareApplication
+  parent_type: Thing


### PR DESCRIPTION
To simplify things a bit (and eliminate the need to introduce new levels in the tree) I am simplifying this repo to just add `ContainerRecipe` and `ContainerImage`, where the first is a type of `SoftwareSourceCode` and the second (it was first discussed as an isolation technology then a package, neither of which is in the tree) I am not just putting under `Thing`.